### PR TITLE
Fix integration test env vars

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,7 +67,7 @@ jobs:
           $env:SIMULATOR_NUM_MESSAGES = $env:SIMULATOR_NUM_MESSAGES_CI
           Write-Host "Environment SIMULATOR_NUM_MESSAGES set to $env:SIMULATOR_NUM_MESSAGES for Aspire AppHost process"
 
-          Start-Process dotnet -ArgumentList "run, --project, FlinkDotNetAspire.AppHost.csproj, --no-launch-profile, --no-build" -NoNewWindow -PassThru
+          Start-Process -FilePath dotnet -ArgumentList "run --project FlinkDotNetAspire.AppHost.csproj --no-launch-profile --no-build" -NoNewWindow -PassThru
           Write-Host "Waiting for Aspire AppHost to initialize..."
           Start-Sleep -Seconds 20
           Pop-Location
@@ -93,7 +93,7 @@ jobs:
           $redisConnectionString = $manifestContent.resources.redis.connectionString
           if ($redisConnectionString) {
             Write-Host "Found Redis connection string: $redisConnectionString"
-            echo "##vso[task.setvariable variable=DOTNET_REDIS_URL]$redisConnectionString"
+            Add-Content -Path $env:GITHUB_ENV -Value "DOTNET_REDIS_URL=$redisConnectionString"
           } else {
             Write-Warning "Redis connection string not found in manifest. Verifier might fail if it relies on it."
           }
@@ -117,7 +117,7 @@ jobs:
 
           if ($kafkaBootstrapServers) {
             Write-Host "Found Kafka bootstrap servers: $kafkaBootstrapServers"
-            echo "##vso[task.setvariable variable=DOTNET_KAFKA_BOOTSTRAP_SERVERS]$kafkaBootstrapServers"
+            Add-Content -Path $env:GITHUB_ENV -Value "DOTNET_KAFKA_BOOTSTRAP_SERVERS=$kafkaBootstrapServers"
           } else {
             Write-Warning "Kafka bootstrap servers not found in manifest using common patterns. Verifier might fail if it relies on it."
             Write-Host "Attempted to find: \$manifestContent.resources.kafka.bootstrapServers"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+This repo uses .NET 8.0 and the .NET Aspire workload.
+Install Docker CE so Aspire's AppHost can start Redis and Kafka containers.
+Typical commands:
+- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal` for unit tests.
+- Integration tests mimic `.github/workflows/integration-tests.yml` and need Docker running.
+

--- a/FlinkDotNet/FlinkDotNet.JobManager.Tests/HighAvailabilityCoordinatorTests.cs
+++ b/FlinkDotNet/FlinkDotNet.JobManager.Tests/HighAvailabilityCoordinatorTests.cs
@@ -6,11 +6,11 @@ namespace FlinkDotNet.JobManager.Tests
     public class HighAvailabilityCoordinatorTests
     {
         [Fact]
-        public void AcquireAndResign()
+        public async Task AcquireAndResign()
         {
             var ha = new HighAvailabilityCoordinator();
             Assert.False(ha.IsLeader);
-            Assert.True(ha.TryAcquireLeadershipAsync().Result);
+            Assert.True(await ha.TryAcquireLeadershipAsync());
             Assert.True(ha.IsLeader);
             ha.ResignLeadership();
             Assert.False(ha.IsLeader);


### PR DESCRIPTION
## Summary
- ensure the Aspire manifest parsing step correctly exports variables in integration tests
- keep Aspire AppHost start command using Start-Process with a single argument string
- make `AcquireAndResign` test async to avoid blocking
- add AGENTS.md describing local environment requirements

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6846ea336d588322b0c6cabfab75d096