### PR TITLE
Fix Aspire AppHost manifest generation

### DIFF
--- a/FlinkDotNetAspire/FlinkDotNetAspire.AppHost/FlinkDotNetAspire.AppHost.csproj
+++ b/FlinkDotNetAspire/FlinkDotNetAspire.AppHost/FlinkDotNetAspire.AppHost.csproj
@@ -7,6 +7,7 @@
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\FlinkDotNetAspire.ServiceDefaults\FlinkDotNetAspire.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\FlinkDotNet\FlinkDotNet.JobManager\FlinkDotNet.JobManager.csproj" />
     <ProjectReference Include="..\..\FlinkDotNet\FlinkDotNet.TaskManager\FlinkDotNet.TaskManager.csproj" />
@@ -14,6 +15,8 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Reference Aspire hosting so DistributedApplication source generators compile -->
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.2" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.2.2" />
+    <PackageReference Include="Aspire.Hosting.Kafka" Version="8.2.2" />
   </ItemGroup>
 </Project>

--- a/FlinkDotNetAspire/FlinkDotNetAspire.AppHost/Program.cs
+++ b/FlinkDotNetAspire/FlinkDotNetAspire.AppHost/Program.cs
@@ -12,7 +12,7 @@ var jobManagerGrpcEndpoint = "http://localhost:50051";
 
 var jobManager = builder.AddProject<Projects.FlinkDotNet_JobManager>("jobmanager")
     .WithHttpEndpoint(targetPort: 8080, name: "rest")
-    .WithEndpoint(targetPort:50051, name: "grpc", scheme: "http", protocol: Microsoft.AspNetCore.Hosting.Server.Protocols.HttpProtocols.Http2)
+    .WithEndpoint(targetPort:50051, name: "grpc", scheme: "http")
     .WithEnvironment("ASPNETCORE_URLS", $"{jobManagerHttpEndpoint};{jobManagerGrpcEndpoint}")
     .WithEnvironment("DOTNET_ENVIRONMENT", "Development");
 


### PR DESCRIPTION
## Summary
- reference Microsoft.AspNetCore.App and use Aspire packages version 8.2.2
- simplify gRPC endpoint configuration for .NET 8 package version

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_684701d690f0832285738ef5a8690c5c