### PR TITLE
Fix manifest path in integration workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,8 +54,8 @@ jobs:
           Push-Location FlinkDotNetAspire/FlinkDotNetAspire.AppHost
 
           echo "Generating Aspire manifest..."
-          dotnet publish FlinkDotNetAspire.AppHost.csproj --configuration Release --output ../publish
-          Copy-Item ../publish/aspire-manifest.json ../aspire-manifest.json
+          dotnet publish FlinkDotNetAspire.AppHost.csproj --configuration Release -p:IsPublishable=true -p:AspireManifestPublishOutputPath=../publish -t:GenerateAspireManifest
+          Copy-Item ../publish/manifest.json ../aspire-manifest.json
           Write-Host "Aspire manifest generated at ../aspire-manifest.json"
 
           # Start Aspire in the background. Pass SIMULATOR_NUM_MESSAGES to the environment of the process


### PR DESCRIPTION
## Summary
- update integration workflow to generate Aspire manifest correctly

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68470fcd60b88322a91c5a56b1f9c00e