### PR TITLE
Clean up commented code and namespace declarations

### DIFF
--- a/FlinkDotNet/FlinkDotNet.JobManager/Models/JobGraph/KeyingInfo.cs
+++ b/FlinkDotNet/FlinkDotNet.JobManager/Models/JobGraph/KeyingInfo.cs
@@ -18,10 +18,7 @@ namespace FlinkDotNet.JobManager.Models.JobGraph
         /// </summary>
         public string KeyTypeAssemblyName { get; }
 
-        // In the previous version, it had:
-        // public string? SerializedKeySelector { get; set; }
-        // public string? KeyTypeName { get; set; }
-        // The current version aligns better with OutputKeyingConfig structure.
+
 
         public KeyingInfo(string keySelectorTypeName, string keyTypeAssemblyName)
         {

--- a/FlinkDotNet/FlinkDotNet.JobManager/Program.cs
+++ b/FlinkDotNet/FlinkDotNet.JobManager/Program.cs
@@ -2,6 +2,7 @@ using FlinkDotNet.JobManager.Interfaces;
 using FlinkDotNet.JobManager.Services;
 using FlinkDotNet.JobManager.Checkpointing; // Added for CheckpointCoordinator
 using FlinkDotNet.JobManager.Models; // Added for JobManagerConfig
+using FlinkDotNet.JobManager;
 using System;
 using System.Linq; // Required for Enumerable
 using Microsoft.Extensions.Hosting; // Added for AddServiceDefaults
@@ -16,7 +17,6 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSingleton<IJobRepository, InMemoryJobRepository>();
 // If InMemoryJobRepository itself needs to be resolved directly (it doesn't seem to be),
 // it would also be covered by AddSingleton<IJobRepository, InMemoryJobRepository>() if it's the implementation.
-// For clarity, if it were ever resolved directly: builder.Services.AddSingleton<InMemoryJobRepository>();
 builder.Services.AddSwaggerGen();
 builder.Services.AddGrpc(); // Added for gRPC
 
@@ -70,18 +70,14 @@ app.MapGet("/weatherforecast", () =>
 // If API controllers are not found, explicit registration might be needed.
 // For now, assuming JobManagerController (REST API) is correctly mapped by existing setup.
 
-// Test CheckpointCoordinator setup - This is now outdated due to constructor changes
-// var testJobId = "test-job-001";
-// var coordinatorConfig = new JobManagerConfig { CheckpointIntervalSecs = 15 };
-// ILogger<CheckpointCoordinator> dummyCoordinatorLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<CheckpointCoordinator>();
-// IJobRepository dummyRepo = app.Services.GetRequiredService<IJobRepository>();
-// var checkpointCoordinator = new CheckpointCoordinator(testJobId, dummyRepo, dummyCoordinatorLogger, coordinatorConfig);
-// TaskManagerRegistrationServiceImpl.JobCoordinators.TryAdd(testJobId, checkpointCoordinator);
-// checkpointCoordinator.Start();
 
 app.Run();
 
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+namespace FlinkDotNet.JobManager
 {
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+    {
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    }
 }
+

--- a/FlinkDotNet/FlinkDotNet.JobManager/Services/Checkpointing/CheckpointCoordinator.cs
+++ b/FlinkDotNet/FlinkDotNet.JobManager/Services/Checkpointing/CheckpointCoordinator.cs
@@ -127,7 +127,6 @@ namespace FlinkDotNet.JobManager.Checkpointing
             _logger.LogInformation("Job {JobId}: All TriggerTaskCheckpoint messages sent for checkpoint {CheckpointId}.", _jobId, checkpointId);
             // Start a timer here for 'checkpointId'. If it fires before the checkpoint is fully acknowledged,
             // call 'RecordFailedCheckpointAsync(checkpointId, "Timeout")' and potentially cancel ongoing efforts for this CP.
-            // Example: _checkpointTimeoutController.RegisterTimeout(checkpointId, _config.CheckpointTimeoutSecs, async () => await RecordFailedCheckpointAsync(checkpointId, "Timeout"));
             Console.WriteLine($"[CheckpointCoordinator] Placeholder for starting timeout timer for checkpoint {checkpointId}.");
         }
 
@@ -159,7 +158,6 @@ namespace FlinkDotNet.JobManager.Checkpointing
                     };
                     _jobRepository.AddCheckpointAsync(_jobId, checkpointDto).ConfigureAwait(false); // Fire and forget for now
                     // and potentially from the _jobRepository / durable storage based on retention policy.
-                    // Example: if (_checkpoints.Count > _config.MaxRetainedCheckpoints) { /* logic to find and remove oldest */ }
                     Console.WriteLine($"[CheckpointCoordinator] Placeholder for cleaning up old checkpoints after CP {checkpoint.CheckpointId} completed.");
                 }
                 // Optional: Check if checkpoint has failed due to some tasks failing

--- a/FlinkDotNet/FlinkDotNet.JobManager/Services/InMemoryJobRepository.cs
+++ b/FlinkDotNet/FlinkDotNet.JobManager/Services/InMemoryJobRepository.cs
@@ -81,12 +81,7 @@ namespace FlinkDotNet.JobManager.Services
                 return Task.CompletedTask;
             }
 
-            // Ensure the job exists before adding a checkpoint for it (optional, but good practice)
-            // if (!_jobStatuses.ContainsKey(jobId))
-            // {
-            //     // Or throw new InvalidOperationException($"Job with ID {jobId} not found. Cannot add checkpoint.");
-            //     return Task.CompletedTask;
-            // }
+
 
             var checkpoints = _jobCheckpoints.GetOrAdd(jobId, _ => new List<CheckpointInfoDto>());
             lock (checkpoints) // ConcurrentDictionary GetOrAdd is atomic for list creation, but adding to list needs sync

--- a/FlinkDotNet/FlinkDotNet.JobManager/Services/JobManagerInternalApiService.cs
+++ b/FlinkDotNet/FlinkDotNet.JobManager/Services/JobManagerInternalApiService.cs
@@ -238,15 +238,6 @@ namespace FlinkDotNet.JobManager.Services
 
             // In a real implementation, this would trigger checkpoint cancellation or recovery logic.
             // For now, just acknowledge the report.
-            // Example: Find the CheckpointCoordinator for the job and notify it.
-            // if (TaskManagerRegistrationServiceImpl.JobCoordinators.TryGetValue(request.JobId, out var coordinator))
-            // {
-            //     coordinator.HandleFailedCheckpoint(request.CheckpointId, request.JobVertexId, request.SubtaskIndex, request.FailureReason);
-            // }
-            // else
-            // {
-            //     _logger.LogError($"Could not find CheckpointCoordinator for JobId {request.JobId} to report failed checkpoint {request.CheckpointId}.");
-            // }
 
             return Task.FromResult(new global::FlinkDotNet.Proto.Internal.ReportFailedCheckpointResponse
             {
@@ -259,7 +250,6 @@ namespace FlinkDotNet.JobManager.Services
         {
             _logger.LogWarning($"[JobManager] Received task startup failure report from TM {request.TaskManagerId} for Job {request.JobId}, Task {request.JobVertexId}_{request.SubtaskIndex}. Reason: {request.FailureReason}");
             // For now, just log and acknowledge.
-            // Example: _jobRepository.UpdateTaskStatus(request.JobId, request.JobVertexId, request.SubtaskIndex, JobStatus.Failed, request.FailureReason);
             return Task.FromResult(new global::FlinkDotNet.Proto.Internal.ReportTaskStartupFailureResponse { Acknowledged = true });
         }
     }

--- a/FlinkDotNet/FlinkDotNet.JobManager/Services/TaskManagerRegistrationService.cs
+++ b/FlinkDotNet/FlinkDotNet.JobManager/Services/TaskManagerRegistrationService.cs
@@ -118,7 +118,6 @@ public class TaskManagerRegistrationServiceImpl : Proto.TaskManagerRegistration.
                 if (parts.Length >= 1) // At least JobVertexId should be there
                 {
                     jobVertexIdStr = parts[0];
-                    // if (parts.Length > 1) int.TryParse(parts[1], out subtaskIndex);
                 }
 
                 if (Guid.TryParse(jobVertexIdStr, out jobVertexGuid))


### PR DESCRIPTION
## Summary
- remove leftover commented code blocks across services
- wrap `WeatherForecast` in the JobManager namespace
- clean up unused commented lines

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6847173c87dc8322a9f25074b4d02201