### PR TITLE
Improve build warning detection

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -67,10 +67,19 @@ jobs:
             function RunBuildWithWarningCheck($project) {
               Write-Host "Building $project"
               $output = dotnet build $project 2>&1
+
+              if (-not $output) {
+                Write-Host "[DEBUG] Build output was empty"
+              } else {
+                Write-Host "[DEBUG] Captured $($output.Count) output line(s)"
+              }
+
               $output | ForEach-Object { Write-Host $_ }
 
-              $warnings = $output | Where-Object { $_ -match "(?i)^\s*warning" }
+              $warnings = $output | Where-Object { $_ -match "(?i)warning" }
+              Write-Host "[DEBUG] Found $($warnings.Count) line(s) containing 'warning'"
               if ($warnings.Count -gt 0) {
+                Write-Host "[DEBUG] First warning: $($warnings[0])"
                 Write-Host "[WARN] Found $($warnings.Count) warning(s) in $project"
                 return 1
               }


### PR DESCRIPTION
## Summary
- patch SonarCloud workflow script to better detect warnings and add debugging output

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847179be6688322a2152083bf48a37c