### PR TITLE
Speed up IT container

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Start Integration Test Container
         run: |
-          docker run -d --name integration-test -e SIMULATOR_NUM_MESSAGES=${{ env.SIMULATOR_NUM_MESSAGES_CI }} -e ASPIRE_ALLOW_UNSECURED_TRANSPORT="true" -e ASPNETCORE_URLS="http://0.0.0.0:5199" -e DOTNET_DASHBOARD_OTLP_ENDPOINT_URL="http://localhost:4317" -p 5199:5199 -p 6379:6379 -p 9092:9092 -p 8088:8088 -p 50051:50051 -p 4317:4317 ghcr.io/devstress/flink-dotnet-windows:latest
+          docker run --privileged -d --name integration-test -e SIMULATOR_NUM_MESSAGES=${{ env.SIMULATOR_NUM_MESSAGES_CI }} -e ASPIRE_ALLOW_UNSECURED_TRANSPORT="true" -e ASPNETCORE_URLS="http://0.0.0.0:5199" -e DOTNET_DASHBOARD_OTLP_ENDPOINT_URL="http://localhost:4317" -p 5199:5199 -p 6379:6379 -p 9092:9092 -p 8088:8088 -p 50051:50051 -p 4317:4317 ghcr.io/devstress/flink-dotnet-windows:latest
           Write-Host "Waiting for container to initialize..."
           Start-Sleep -Seconds 30
 

--- a/IntegrationTestImage/Dockerfile
+++ b/IntegrationTestImage/Dockerfile
@@ -1,0 +1,32 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish IntegrationTestImage/IntegrationTestImage.csproj -c Release -o /app/publish
+
+# Final stage with Docker-in-Docker
+FROM docker:26-dind
+WORKDIR /app
+
+# Install .NET 8 runtime and Aspire workload
+ENV DOTNET_ROOT=/usr/share/dotnet
+ENV PATH="$PATH:/usr/share/dotnet"
+RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
+    && chmod +x dotnet-install.sh \
+    && ./dotnet-install.sh --version 8.0.116 --install-dir $DOTNET_ROOT \
+    && ln -s $DOTNET_ROOT/dotnet /usr/bin/dotnet \
+    && dotnet workload install aspire
+
+# Pre-fetch Redis and Kafka images and store as archives
+RUN dockerd-entrypoint.sh & \
+    sleep 5 && \
+    docker pull redis:latest && \
+    docker pull confluentinc/cp-kafka:latest && \
+    docker save redis:latest -o /redis.tar && \
+    docker save confluentinc/cp-kafka:latest -o /kafka.tar && \
+    pkill dockerd
+
+COPY --from=build /app/publish .
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/IntegrationTestImage/IntegrationTestImage.csproj
+++ b/IntegrationTestImage/IntegrationTestImage.csproj
@@ -3,9 +3,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <PublishProfile>DefaultContainer</PublishProfile>
+    <Dockerfile>Dockerfile</Dockerfile>
+    <DockerfileContextDirectory>..</DockerfileContextDirectory>
     <ContainerImageName>flink-dotnet-windows</ContainerImageName>
-    <ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:8.0-nanoserver-ltsc2022</ContainerBaseImage>
-    <ContainerRuntimeIdentifier>win-x64</ContainerRuntimeIdentifier>
+    <ContainerImageTags>latest</ContainerImageTags>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\FlinkDotNetAspire\FlinkDotNetAspire.AppHost\FlinkDotNetAspire.AppHost.csproj" />

--- a/IntegrationTestImage/Properties/PublishProfiles/DockerDeploy.pubxml
+++ b/IntegrationTestImage/Properties/PublishProfiles/DockerDeploy.pubxml
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
     <PublishProfile>DefaultContainer</PublishProfile>
+    <Dockerfile>Dockerfile</Dockerfile>
+    <DockerfileContextDirectory>..</DockerfileContextDirectory>
     <ContainerRegistry></ContainerRegistry>
     <ContainerImageName>flink-dotnet-windows</ContainerImageName>
     <ContainerImageTags>latest</ContainerImageTags>
-    <ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:8.0-nanoserver-ltsc2022</ContainerBaseImage>
-    <ContainerRuntimeIdentifier>win-x64</ContainerRuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/IntegrationTestImage/entrypoint.sh
+++ b/IntegrationTestImage/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# Start Docker daemon
+/dockerd-entrypoint.sh &
+
+# Wait for Docker to be ready
+until docker info >/dev/null 2>&1; do
+  sleep 1
+done
+
+# Load cached images
+if [ -f /redis.tar ]; then
+  docker load -i /redis.tar || true
+fi
+if [ -f /kafka.tar ]; then
+  docker load -i /kafka.tar || true
+fi
+
+exec dotnet IntegrationTestImage.dll "$@"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A PowerShell script is provided for executing the integration tests locally. It 
 ./scripts/run-integration-tests.ps1
 ```
 
-The script pulls the prebuilt Docker image, starts a container running the Aspire AppHost (including Redis and Kafka), performs health checks, and then executes the verification tests.
+The script pulls the prebuilt Docker image, which now contains the .NET Aspire workload, an embedded Docker daemon, and cached Redis and Kafka images. The daemon starts automatically inside the container so the AppHost can launch its dependencies instantly. After a brief health check the verification tests run.
 
 By default, the image is retrieved from `ghcr.io/devstress/flink-dotnet-windows:latest`. Set the environment variable `FLINK_IMAGE_REPOSITORY` to override the repository if needed.
 


### PR DESCRIPTION
## Summary
- customize `IntegrationTestImage` build to use a Dockerfile
- install Aspire workload and Docker engine in the image
- preload Redis and Kafka images for quick startup
- document that the container starts its own Docker daemon
- run integration tests container in privileged mode

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`
- *(failed to run integration tests: `pwsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847fda9788083229b483caf0f15cded