### PR TITLE
Switch integration tests to Linux container

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   run-integration-tests:
     name: Run Flink.NET Integration Tests
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     defaults:
       run:
@@ -30,12 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure Docker is running
-        run: |
-          if (-not (Get-Service -Name com.docker.service -ErrorAction SilentlyContinue)) {
-            choco install docker-desktop --pre -y
-          }
-          Start-Service com.docker.service
-          docker info
+        run: docker info
 
       - name: Set up .NET 8.0
         uses: actions/setup-dotnet@v4
@@ -60,11 +55,11 @@ jobs:
 
       - name: Pull Integration Test Docker Image
         run: |
-          docker pull ghcr.io/devstress/flink-dotnet-windows:latest
+          docker pull ghcr.io/devstress/flink-dotnet-linux:latest
 
       - name: Start Integration Test Container
         run: |
-          docker run --privileged -d --name integration-test -e SIMULATOR_NUM_MESSAGES=${{ env.SIMULATOR_NUM_MESSAGES_CI }} -e ASPIRE_ALLOW_UNSECURED_TRANSPORT="true" -e ASPNETCORE_URLS="http://0.0.0.0:5199" -e DOTNET_DASHBOARD_OTLP_ENDPOINT_URL="http://localhost:4317" -p 5199:5199 -p 6379:6379 -p 9092:9092 -p 8088:8088 -p 50051:50051 -p 4317:4317 ghcr.io/devstress/flink-dotnet-windows:latest
+          docker run --privileged -d --name integration-test -e SIMULATOR_NUM_MESSAGES=${{ env.SIMULATOR_NUM_MESSAGES_CI }} -e ASPIRE_ALLOW_UNSECURED_TRANSPORT="true" -e ASPNETCORE_URLS="http://0.0.0.0:5199" -e DOTNET_DASHBOARD_OTLP_ENDPOINT_URL="http://localhost:4317" -p 5199:5199 -p 6379:6379 -p 9092:9092 -p 8088:8088 -p 50051:50051 -p 4317:4317 ghcr.io/devstress/flink-dotnet-linux:latest
           Write-Host "Waiting for container to initialize..."
           Start-Sleep -Seconds 30
 

--- a/.github/workflows/publish-integration-test-image.yml
+++ b/.github/workflows/publish-integration-test-image.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish-image:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: pwsh
@@ -33,5 +33,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Image
         run: |
-          docker tag flink-dotnet-windows:latest ghcr.io/${{ github.repository_owner }}/flink-dotnet-windows:latest
-          docker push ghcr.io/${{ github.repository_owner }}/flink-dotnet-windows:latest
+          docker tag flink-dotnet-linux:latest ghcr.io/${{ github.repository_owner }}/flink-dotnet-linux:latest
+          docker push ghcr.io/${{ github.repository_owner }}/flink-dotnet-linux:latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,6 @@ If the dotnet CLI is missing, install the .NET 8 SDK using Ubuntu packages with:
 The dotnet-install script can fail on newer distributions.
 Typical commands:
 - `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal` for unit tests.
-- Integration tests mimic `.github/workflows/integration-tests.yml` and require Docker.
-  They pull `ghcr.io/devstress/flink-dotnet-windows:latest` by default.
-  You can also run `scripts/run-integration-tests.ps1` on Windows to reproduce the workflow.
+- Integration tests mimic `.github/workflows/integration-tests.yml` and require Docker. They run inside a Linux container.
+  They pull `ghcr.io/devstress/flink-dotnet-linux:latest` by default.
+  You can also run `scripts/run-integration-tests-in-windows-os.ps1` on Windows to reproduce the workflow.

--- a/IntegrationTestImage/IntegrationTestImage.csproj
+++ b/IntegrationTestImage/IntegrationTestImage.csproj
@@ -5,7 +5,7 @@
     <PublishProfile>DefaultContainer</PublishProfile>
     <Dockerfile>Dockerfile</Dockerfile>
     <DockerfileContextDirectory>..</DockerfileContextDirectory>
-    <ContainerImageName>flink-dotnet-windows</ContainerImageName>
+    <ContainerImageName>flink-dotnet-linux</ContainerImageName>
     <ContainerImageTags>latest</ContainerImageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/IntegrationTestImage/Properties/PublishProfiles/DockerDeploy.pubxml
+++ b/IntegrationTestImage/Properties/PublishProfiles/DockerDeploy.pubxml
@@ -4,7 +4,7 @@
     <Dockerfile>Dockerfile</Dockerfile>
     <DockerfileContextDirectory>..</DockerfileContextDirectory>
     <ContainerRegistry></ContainerRegistry>
-    <ContainerImageName>flink-dotnet-windows</ContainerImageName>
+    <ContainerImageName>flink-dotnet-linux</ContainerImageName>
     <ContainerImageTags>latest</ContainerImageTags>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ Explore practical examples to understand Flink.NET's capabilities:
 
 ## Running Integration Tests on Windows
 
-A PowerShell script is provided for executing the integration tests locally. It automatically installs the .NET 8 SDK and Docker Desktop using `winget` if they are missing. The tests now run inside a prebuilt Docker image (`flink-dotnet-windows`) that can also be used by the CI workflow. Run the script from an elevated PowerShell prompt:
+A PowerShell script is provided for executing the integration tests locally. It automatically installs the .NET 8 SDK and Docker Desktop using `winget` if they are missing. The tests now run inside a prebuilt Linux Docker image (`flink-dotnet-linux`) that can also be used by the CI workflow. Run the script from an elevated PowerShell prompt:
 
 ```powershell
-./scripts/run-integration-tests.ps1
+pwsh scripts/run-integration-tests-in-windows-os.ps1
 ```
 
 The script pulls the prebuilt Docker image, which now contains the .NET Aspire workload, an embedded Docker daemon, and cached Redis and Kafka images. The daemon starts automatically inside the container so the AppHost can launch its dependencies instantly. After a brief health check the verification tests run.
 
-By default, the image is retrieved from `ghcr.io/devstress/flink-dotnet-windows:latest`. Set the environment variable `FLINK_IMAGE_REPOSITORY` to override the repository if needed.
+By default, the image is retrieved from `ghcr.io/devstress/flink-dotnet-linux:latest`. Set the environment variable `FLINK_IMAGE_REPOSITORY` to override the repository if needed.
 
 ### Integration Test Image on GHCR
 
-The Windows Docker image used for integration tests is published publicly to GitHub Container Registry (GHCR) at `ghcr.io/devstress/flink-dotnet-windows:latest`. Instructions on publishing or updating the image via GitHub Actions are available in [GHCR Public Image and GitHub Actions](./docs/wiki/GHCR-Tokens.md).
+The Linux Docker image used for integration tests is published publicly to GitHub Container Registry (GHCR) at `ghcr.io/devstress/flink-dotnet-linux:latest`. Instructions on publishing or updating the image via GitHub Actions are available in [GHCR Public Image and GitHub Actions](./docs/wiki/GHCR-Tokens.md).
 
 ## AI-Assisted Development
 The development of Flink.NET has been significantly accelerated and enhanced with the assistance of ChatGPT's Codex AI and Google's Jules AI, showcasing a modern approach to software engineering.

--- a/docs/wiki/GHCR-Tokens.md
+++ b/docs/wiki/GHCR-Tokens.md
@@ -5,7 +5,7 @@ This guide explains how to publish the integration test Docker image to GitHub C
 ## 1. Make the GHCR Package Public
 
 1. After the image is pushed the first time, open the **Packages** section of your repository on GitHub.
-2. Select the `flink-dotnet-windows` package.
+2. Select the `flink-dotnet-linux` package.
 3. Under **Package settings**, change the visibility to **Public**.
 
 Once the package is public, anyone can pull the image without authentication.

--- a/scripts/run-integration-tests-in-windows-os.ps1
+++ b/scripts/run-integration-tests-in-windows-os.ps1
@@ -1,3 +1,10 @@
+<#
+    This script reproduces the GitHub integration test workflow on a Windows
+    machine. Invoke it with PowerShell using the following command:
+
+        pwsh scripts/run-integration-tests-in-windows-os.ps1
+#>
+
 param(
     [string]$SimMessages = "1000000"
 )
@@ -36,9 +43,9 @@ dotnet workload restore FlinkDotNet.WebUI/FlinkDotNet.WebUI.sln
 
 # Acquire Integration Test Docker image
 if ($env:FLINK_IMAGE_REPOSITORY) {
-    $imageName = "$($env:FLINK_IMAGE_REPOSITORY)/flink-dotnet-windows:latest"
+    $imageName = "$($env:FLINK_IMAGE_REPOSITORY)/flink-dotnet-linux:latest"
 } else {
-    $imageName = "ghcr.io/devstress/flink-dotnet-windows:latest"
+    $imageName = "ghcr.io/devstress/flink-dotnet-linux:latest"
 }
 Write-Host "Pulling docker image $imageName..."
 docker pull $imageName


### PR DESCRIPTION
## Summary
- rename PowerShell script for Windows runs
- rename integration test image to flink-dotnet-linux
- switch integration test workflow to Ubuntu and Linux container
- update Docker image publishing workflow
- update docs and AGENTS instructions

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`
- ❌ `docker pull ghcr.io/devstress/flink-dotnet-linux:latest` *(failed: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6848044857808322a863b2ca0f41b3a4