### PR TITLE
Fix integration test image publish

### DIFF
--- a/.github/workflows/publish-integration-test-image.yml
+++ b/.github/workflows/publish-integration-test-image.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install .NET Aspire Workload
         run: dotnet workload install aspire
       - name: Build Docker Image
-        run: dotnet publish IntegrationTestImage/IntegrationTestImage.csproj -p:PublishProfile=DockerDeploy
+        run: docker build -t flink-dotnet-linux:latest -f IntegrationTestImage/Dockerfile .
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- fix the publish workflow to build docker image using `docker build`

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684806d5792483229cadb28fd7a101eb