### PR TITLE
Update integration test workflow dependency

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,10 @@
 name: Integration Tests
 
 on:
+  workflow_run:
+    workflows: ["Publish Integration Test Image"]
+    types:
+      - completed
   push:
     branches:
       - main # Or your primary branch name
@@ -18,6 +22,7 @@ jobs:
   run-integration-tests:
     name: Run Flink.NET Integration Tests
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     defaults:
       run:

--- a/.github/workflows/publish-integration-test-image.yml
+++ b/.github/workflows/publish-integration-test-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - 'IntegrationTestImage/**'
-      - 'workflows/publish-integration-test-image.yml'
+      - '.github/workflows/publish-integration-test-image.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- trigger Integration Tests after the Publish Integration Test Image workflow completes
- only run the integration tests job if the publish workflow succeeded
- fix path pattern in the publish workflow to match the file location

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`
- ❌ `docker --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480e5fa7dc832286fc15e847d8f9c8