### PR TITLE
Fix Dockerfile path

### DIFF
--- a/IntegrationTestImage/Dockerfile
+++ b/IntegrationTestImage/Dockerfile
@@ -27,6 +27,6 @@ RUN dockerd-entrypoint.sh & \
     pkill dockerd
 
 COPY --from=build /app/publish .
-COPY entrypoint.sh /entrypoint.sh
+COPY IntegrationTestImage/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- fix path to entrypoint in IntegrationTestImage Dockerfile

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`
- `docker build -t flink-dotnet-linux:latest -f IntegrationTestImage/Dockerfile .` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68481002fdcc8322aca2df5ff264f3cc