### PR TITLE
Limit image publish to master pushes

### DIFF
--- a/.github/workflows/publish-integration-test-image.yml
+++ b/.github/workflows/publish-integration-test-image.yml
@@ -2,6 +2,8 @@ name: Publish Integration Test Image
 
 on:
   push:
+    branches:
+      - master
     paths:
       - 'IntegrationTestImage/**'
       - '.github/workflows/publish-integration-test-image.yml'


### PR DESCRIPTION
## Summary
- only publish `flink-dotnet-linux` integration test image when pushing to `master`

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6848181853c48322997a9b23f218bd8d