### PR TITLE
Remove manual dotnet setup

### DIFF
--- a/.github/workflows/publish-integration-test-image.yml
+++ b/.github/workflows/publish-integration-test-image.yml
@@ -18,12 +18,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up .NET 8.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
-      - name: Install .NET Aspire Workload
-        run: dotnet workload install aspire
       - name: Build Docker Image
         run: docker build -t flink-dotnet-linux:latest -f IntegrationTestImage/Dockerfile .
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
## Summary
- use the prebuilt integration test image `flink-dotnet-linux` as the toolchain and remove the .NET Aspire setup steps from the publishing workflow

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6848186ff4bc8322a2e2ab6e70b37ba1