### PR TITLE
Update docs for GHCR test image

### DIFF
--- a/docs/wiki/Deployment-Local.md
+++ b/docs/wiki/Deployment-Local.md
@@ -76,7 +76,7 @@ A true in-process local runner would be beneficial for very quick unit tests of 
 
 Using the `FlinkDotNetAspire` setup provides a robust and feature-rich environment for developing, testing, and debugging your Flink.NET applications locally.
 
-For publishing the integration test image, follow the instructions in [GHCR Public Image and GitHub Actions](GHCR-Tokens.md).
+The integration tests run inside a prebuilt Docker image published to GitHub Container Registry: `ghcr.io/devstress/flink-dotnet-linux:latest`. You can pull this image directly for local testing. To publish updates, follow the instructions in [GHCR Public Image and GitHub Actions](GHCR-Tokens.md).
 
 ---
 [Home](https://github.com/devstress/FLINK.NET/blob/main/docs/wiki/Wiki-Structure-Outline.md)

--- a/docs/wiki/GHCR-Tokens.md
+++ b/docs/wiki/GHCR-Tokens.md
@@ -1,6 +1,7 @@
 # GHCR Public Image and GitHub Actions
 
 This guide explains how to publish the integration test Docker image to GitHub Container Registry (GHCR) and make it publicly accessible.
+The image is available at `ghcr.io/devstress/flink-dotnet-linux:latest` for anyone to pull and run the integration tests locally.
 
 ## 1. Make the GHCR Package Public
 

--- a/docs/wiki/Sample-Local-High-Throughput-Test.md
+++ b/docs/wiki/Sample-Local-High-Throughput-Test.md
@@ -4,7 +4,7 @@ This guide explains how to set up a local Flink.NET environment using the .NET A
 
 ## Prerequisites
 
-1.  **.NET 9.0 SDK:** Ensure you have the .NET 9.0 SDK installed.
+1.  **.NET 8.0 SDK:** Ensure you have the .NET 8.0 SDK installed.
 2.  **.NET Aspire Workload:** Install the Aspire workload:
     ```bash
     dotnet workload install aspire


### PR DESCRIPTION
## Summary
- note public ghcr image in GHCR-Tokens wiki
- mention ghcr test image in local deployment docs
- fix sample guide to reference .NET 8 SDK

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68483b3c5e188322bb85024e64998579