### PR TITLE
Add Linux script for integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,4 @@ Typical commands:
 - `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal` for unit tests.
 - Integration tests mimic `.github/workflows/integration-tests.yml` and require Docker. They run inside a Linux container.
   They pull `ghcr.io/devstress/flink-dotnet-linux:latest` by default.
-  You can also run `scripts/run-integration-tests-in-windows-os.ps1` on Windows to reproduce the workflow.
+  Use `scripts/run-integration-tests-in-linux.sh` on Linux or `scripts/run-integration-tests-in-windows-os.ps1` on Windows to reproduce the workflow locally.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ The script pulls the prebuilt Docker image, which now contains the .NET Aspire w
 
 By default, the image is retrieved from `ghcr.io/devstress/flink-dotnet-linux:latest`. Set the environment variable `FLINK_IMAGE_REPOSITORY` to override the repository if needed.
 
+## Running Integration Tests on Linux
+
+Linux users can run the integration tests using the accompanying shell script:
+
+```bash
+bash scripts/run-integration-tests-in-linux.sh
+```
+
+Pass an optional argument to control the number of simulated messages. The script verifies that the .NET 8 SDK and Docker are available, pulls the prebuilt image and runs the verification tests after a quick health check.
+
 ### Integration Test Image on GHCR
 
 The Linux Docker image used for integration tests is published publicly to GitHub Container Registry (GHCR) at `ghcr.io/devstress/flink-dotnet-linux:latest`. Instructions on publishing or updating the image via GitHub Actions are available in [GHCR Public Image and GitHub Actions](./docs/wiki/GHCR-Tokens.md).

--- a/scripts/run-integration-tests-in-linux.sh
+++ b/scripts/run-integration-tests-in-linux.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# This script mirrors the GitHub integration test workflow on a Linux machine.
+# Usage: ./scripts/run-integration-tests-in-linux.sh [SimMessages]
+# Requires Docker and the .NET 8 SDK.
+
+set -euo pipefail
+
+SIM_MESSAGES="${1:-1000000}"
+IMAGE_REPO="${FLINK_IMAGE_REPOSITORY:-ghcr.io/devstress}"
+IMAGE_NAME="${IMAGE_REPO}/flink-dotnet-linux:latest"
+CONTAINER_NAME="flink-dotnet-integration"
+
+check_dotnet() {
+    if ! command -v dotnet >/dev/null 2>&1; then
+        echo ".NET SDK not found. Installing via apt-get..."
+        sudo apt-get update
+        sudo apt-get install -y dotnet-sdk-8.0
+    fi
+}
+
+check_docker() {
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "Docker CLI not found. Please install Docker CE and ensure it is running." >&2
+        exit 1
+    fi
+    docker info >/dev/null
+}
+
+build_verifier() {
+    dotnet build FlinkDotNetAspire/IntegrationTestVerifier/IntegrationTestVerifier.csproj -c Release
+}
+
+pull_image() {
+    echo "Pulling Docker image $IMAGE_NAME..."
+    docker pull "$IMAGE_NAME"
+}
+
+start_container() {
+    docker run -d --name "$CONTAINER_NAME" \
+        -e SIMULATOR_NUM_MESSAGES="$SIM_MESSAGES" \
+        -e ASPIRE_ALLOW_UNSECURED_TRANSPORT="true" \
+        -e ASPNETCORE_URLS="http://0.0.0.0:5199" \
+        -e DOTNET_DASHBOARD_OTLP_ENDPOINT_URL="http://localhost:4317" \
+        -p 5199:5199 -p 6379:6379 -p 9092:9092 \
+        -p 8088:8088 -p 50051:50051 -p 4317:4317 \
+        "$IMAGE_NAME"
+}
+
+stop_container() {
+    docker stop "$CONTAINER_NAME" >/dev/null || true
+    docker rm "$CONTAINER_NAME" >/dev/null || true
+}
+
+health_check() {
+    local verifier="./FlinkDotNetAspire/IntegrationTestVerifier/bin/Release/net8.0/FlinkDotNet.IntegrationTestVerifier.dll"
+    for attempt in {1..10}; do
+        echo "Health check attempt $attempt/10..."
+        if dotnet "$verifier" --health-check; then
+            echo "Health check PASSED."
+            return 0
+        fi
+        echo "Health check FAILED. Retrying in 15s..."
+        sleep 15
+    done
+    return 1
+}
+
+run_tests() {
+    local verifier="./FlinkDotNetAspire/IntegrationTestVerifier/bin/Release/net8.0/FlinkDotNet.IntegrationTestVerifier.dll"
+    dotnet "$verifier"
+}
+
+trap stop_container EXIT
+
+check_dotnet
+check_docker
+build_verifier
+pull_image
+start_container
+
+echo "Waiting for container to initialize..."
+sleep 30
+
+if ! health_check; then
+    echo "Health check failed." >&2
+    exit 1
+fi
+
+run_tests


### PR DESCRIPTION
## Summary
- add `run-integration-tests-in-linux.sh` to reproduce workflow locally
- document how to run integration tests on Linux
- mention the new script in `AGENTS.md`

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68483be4ab6c832283e3efad9713e8dd