### PR TITLE
Use rootless Docker in integration test image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 This repo uses .NET 8.0 and the .NET Aspire workload.
-Install Docker CE so Aspire's AppHost can start Redis and Kafka containers.
+Install Docker CE and ensure the daemon is running so Aspire's AppHost can start Redis and Kafka containers.
 If the dotnet CLI is missing, install the .NET 8 SDK using Ubuntu packages with:
 `apt-get update && apt-get install -y dotnet-sdk-8.0`
 The dotnet-install script can fail on newer distributions.

--- a/IntegrationTestImage/Dockerfile
+++ b/IntegrationTestImage/Dockerfile
@@ -16,7 +16,8 @@ RUN dotnet publish IntegrationTestImage/IntegrationTestImage.csproj \
     -o /app/publish
 
 # Final stage with Docker-in-Docker
-FROM docker:26-dind
+# Use the rootless variant so the container can run without --privileged
+FROM docker:26-dind-rootless
 WORKDIR /app
 
 # No runtime installation is required because the app is self-contained


### PR DESCRIPTION
## Summary
- update AGENTS.md instructions to ensure Docker daemon is running
- switch integration test image base to `docker:26-dind-rootless`

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`
- `./scripts/run-integration-tests-in-linux.sh 100` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68483ef92c3483228c97287e7f2447cb