### PR TITLE
Fix health check failures by caching test images

### DIFF
--- a/IntegrationTestImage/Dockerfile
+++ b/IntegrationTestImage/Dockerfile
@@ -19,6 +19,12 @@ RUN dotnet publish IntegrationTestImage/IntegrationTestImage.csproj \
 FROM docker:26-dind
 WORKDIR /app
 
+# Preload Redis and Kafka images so the AppHost can start them without pulling
+# This avoids lengthy network operations during health checks
+RUN apk add --no-cache skopeo \
+    && skopeo copy docker://redis:latest docker-archive:/redis.tar \
+    && skopeo copy docker://confluentinc/cp-kafka:latest docker-archive:/kafka.tar
+
 # No runtime installation is required because the app is self-contained
 COPY --from=build /app/publish/ .
 COPY IntegrationTestImage/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary
- preload Redis and Kafka docker images in the IntegrationTestImage so Aspire can start them quickly

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68483e2ace4c832296493f8fedbff4ca