### PR TITLE
Fix integration test scripts build step

### DIFF
--- a/scripts/run-integration-tests-in-linux.sh
+++ b/scripts/run-integration-tests-in-linux.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
 SIM_MESSAGES="${1:-1000000}"
 IMAGE_REPO="${FLINK_IMAGE_REPOSITORY:-ghcr.io/devstress}"
 IMAGE_NAME="${IMAGE_REPO}/flink-dotnet-linux:latest"

--- a/scripts/run-integration-tests-in-windows-os.ps1
+++ b/scripts/run-integration-tests-in-windows-os.ps1
@@ -55,6 +55,10 @@ function Check-Docker {
     }
 }
 
+function Build-Verifier {
+    dotnet build ../FlinkDotNetAspire/IntegrationTestVerifier/IntegrationTestVerifier.csproj -c Release
+}
+
 Ensure-Admin
 Install-DotNet
 Check-Docker
@@ -77,6 +81,8 @@ Write-Host "Restoring workloads..."
 dotnet workload restore ../FlinkDotNet/FlinkDotNet.sln
 dotnet workload restore ../FlinkDotNetAspire/FlinkDotNetAspire.sln
 dotnet workload restore ../FlinkDotNet.WebUI/FlinkDotNet.WebUI.sln
+
+Build-Verifier
 
 # Acquire Integration Test Docker image
 if ($env:FLINK_IMAGE_REPOSITORY) {


### PR DESCRIPTION
## Summary
- build the verifier before running Windows integration tests
- set script directory in Linux integration script

## Testing
- `dotnet test FlinkDotNet/FlinkDotNet.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684848002a788322baca17289a605c08